### PR TITLE
Add dpl alias for docker pull

### DIFF
--- a/.aliases.sh
+++ b/.aliases.sh
@@ -154,6 +154,7 @@ alias dcstart='docker-compose start' # Start services
 alias dcrmv='docker-compose rm -v'   # Remove stopped service containers and associated volumes
 
 # Docker Container and Image Management
+alias dpl='docker pull'                                       # Pull an image from a registry
 alias dps='docker ps -a'                                      # List all containers, both running and stopped
 alias drm='docker container rm'                               # Remove one or more containers
 alias dimg='docker image'                                     # Docker image commands


### PR DESCRIPTION
# Summary

Introduced an alias `dpl` for the `docker pull` command to streamline the process of pulling images from a registry.

## Checklist

- [ ] The change is well-scoped and ready for review
- [ ] I validated the touched files locally or with the available checks
- [ ] Any downstream impact is documented in the PR description

